### PR TITLE
Fix update plugin

### DIFF
--- a/Resource/template/admin/check_plugin_vesrion.twig
+++ b/Resource/template/admin/check_plugin_vesrion.twig
@@ -43,13 +43,11 @@
                         <div class="text-center">
                             <a class="btn btn-ec-regular"
                                href="{{ path('eccube_updater411to412_admin_config') }}">中止</a>
-                            {% if is_ok %}
                             <a class="btn btn-ec-conversion"
                                href="{{ url('eccube_updater411to412_admin_check_permission') }}" {{ csrf_token_for_anchor() }}
                                data-method="post" data-confirm="false">
                                 書き込み権限の確認へ
                             </a>
-                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ec-cube/eccubeupdater410to411",
+  "name": "ec-cube/eccubeupdater411to412",
   "version": "1.0.0",
   "description": "EC-CUBEアップデートプラグイン",
   "type": "eccube-plugin",


### PR DESCRIPTION
以下修正しています。

- composer.jsonのnameを修正
- プラグイン未対応時の制限を解除


4.0.6 -> 4.1.0へのアップデートプラグインでは、インストール済プラグインが4.1未対応の場合はアップデートできないように制限をかけていましたが、4.1以降は不要なため、以前の仕様に戻しました。